### PR TITLE
Automagic deployment to dev site

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,6 @@ script:
 deploy:
   provider: script
   script: script/deploy
+  skip_cleanup: true
   on:
     branch: deployment

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,8 @@ before_install:
 - docker pull arxivvanity/engrafo:latest
 script:
 - script/test
+deploy:
+  provider: script
+  script: script/deploy
+  on:
+    branch: deployment

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ deploy:
   script: script/deploy
   skip_cleanup: true
   on:
-    branch: deployment
+    branch: master

--- a/arxiv_html/settings.py
+++ b/arxiv_html/settings.py
@@ -123,7 +123,13 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.9/howto/static-files/
 
+# Added this to make redirects and static files work in the case that this is
+# not deployed at /, but the server is rewriting to /. I really wanted to not
+# do this, and everything else seems fine if I don't, but here it is. -E
+FORCE_SCRIPT_NAME = env('FORCE_SCRIPT_NAME', default=None)
+
 STATIC_URL = '/static/'
+
 if not DEBUG:
     STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
 STATICFILES_DIRS = [

--- a/deployment/readability/Chart.yaml
+++ b/deployment/readability/Chart.yaml
@@ -1,0 +1,7 @@
+name: arxiv-readability
+version: 0.1
+appVersion: 0.1
+description: Rendering HTML from arXiv LaTeX sources.
+sources:
+  - https://github.com/cul-it/arxiv-readability
+engine: gotpl

--- a/deployment/readability/charts/redis/Chart.yaml
+++ b/deployment/readability/charts/redis/Chart.yaml
@@ -1,0 +1,7 @@
+name: arxiv-redis
+version: 0.1
+appVersion: 3.2.9
+description: Highly-available Redis cluster for arXiv.
+sources:
+  - https://github.com/cul-it/arxiv-k8s
+engine: gotpl

--- a/deployment/readability/charts/redis/templates/redis-master-deployment.yaml
+++ b/deployment/readability/charts/redis/templates/redis-master-deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: "{{ default "redis" .Values.app_name }}-{{ default "redis-master" .Values.master_name }}"
+  labels:
+    subsystem: "{{ .Values.labels.subsystem }}"
+    container: "{{ default "redis" .Values.app_name }}-redis-master"
+    service-group: backend
+    log-style: other
+spec:
+  selector:
+    matchLabels:
+      app: "{{ default "redis" .Values.app_name }}"
+      role: master
+      tier: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: "{{ default "redis" .Values.app_name }}"
+        role: master
+        tier: backend
+        subsystem: "{{ .Values.labels.subsystem }}"
+        container: "{{ default "redis" .Values.app_name }}-redis-master"
+        service-group: backend
+        log-style: other
+    spec:
+      containers:
+      - name: "{{ default "redis" .Values.app_name }}-redis-master"
+        image: arxiv/redis:latest
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        env:
+        - name: ROLE
+          value: master
+        ports:
+        - containerPort: 6379

--- a/deployment/readability/charts/redis/templates/redis-master-service.yaml
+++ b/deployment/readability/charts/redis/templates/redis-master-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ default "redis" .Values.app_name }}-redis-master"
+  labels:
+    app: "{{ default "redis" .Values.app_name }}"
+    role: master
+    tier: backend
+    subsystem: "{{ .Values.labels.subsystem }}"
+    container: "{{ default "redis" .Values.app_name }}-redis-master"
+    service-group: backend
+    log-style: other
+spec:
+  ports:
+  - port: 6379
+    targetPort: 6379
+  selector:
+    app: "{{ default "redis" .Values.app_name }}"
+    role: master
+    tier: backend

--- a/deployment/readability/charts/redis/templates/redis-slave-deployment.yaml
+++ b/deployment/readability/charts/redis/templates/redis-slave-deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: "{{ default "redis" .Values.app_name }}-redis-slave"
+  labels:
+    subsystem: "{{ .Values.labels.subsystem }}"
+    container: "{{ default "redis" .Values.app_name }}-redis-slave"
+    service-group: backend
+    log-style: other
+spec:
+  selector:
+    matchLabels:
+      app: "{{ default "redis" .Values.app_name }}"
+      role: slave
+      tier: backend
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: "{{ default "redis" .Values.app_name }}"
+        role: slave
+        tier: backend
+        subsystem: "{{ .Values.labels.subsystem }}"
+        container: "{{ default "redis" .Values.app_name }}-redis-slave"
+        service-group: backend
+        log-style: other
+    spec:
+      containers:
+      - name: "{{ default "redis" .Values.app_name }}-redis-slave"
+        image: arxiv/redis:latest
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        env:
+        - name: REDIS_MASTER_SERVICE_HOST
+          value: "{{ default "redis-master" .Values.master_name }}"
+        - name: ROLE
+          value: slave
+        ports:
+        - containerPort: 6379

--- a/deployment/readability/charts/redis/templates/redis-slave-service.yaml
+++ b/deployment/readability/charts/redis/templates/redis-slave-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ default "redis" .Values.app_name }}-redis-slave"
+  labels:
+    app: "{{ default "redis" .Values.app_name }}"
+    role: slave
+    tier: backend
+    subsystem: "{{ .Values.labels.subsystem }}"
+    container: "{{ default "redis" .Values.app_name }}-redis-slave"
+    service-group: backend
+    log-style: other
+spec:
+  ports:
+  - port: 6379
+  selector:
+    app: "{{ default "redis" .Values.app_name }}"
+    role: slave
+    tier: backend

--- a/deployment/readability/charts/redis/values.yaml
+++ b/deployment/readability/charts/redis/values.yaml
@@ -1,0 +1,5 @@
+master_name: redis-master
+slave_name: redis-redis
+app_name: readability
+labels:
+  subsystem: labs

--- a/deployment/readability/templates/00-readability-service.yaml
+++ b/deployment/readability/templates/00-readability-service.yaml
@@ -1,0 +1,18 @@
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: 'true'
+  name: arxiv-readability
+  labels:
+    subsystem: "{{ .Values.labels.subsystem }}"
+    container: readability
+    service-group: ui
+    log-style: uwsgi
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    targetPort: 8000
+  selector:
+    subsystem: "{{ .Values.labels.subsystem }}"
+    container: readability

--- a/deployment/readability/templates/10-readability-deployment.yaml
+++ b/deployment/readability/templates/10-readability-deployment.yaml
@@ -34,14 +34,10 @@ spec:
           value: "redis://{{ .Values.redis.host }}:{{ .Values.redis.port}}"
         - name: SECRET_KEY
           value: "{{ .Values.secret_key }}"
-        - name: DEBUG
-          value: "1"
         - name: SCRIPT_NAME
           value: "{{ .Values.script_name }}"
         - name: FORCE_SCRIPT_NAME
           value: "{{ .Values.script_name }}"
-        - name: DJANGO_LOG_LEVEL
-          value: "DEBUG"
         - name: ALLOWED_HOSTS
           value: "*"
 ---

--- a/deployment/readability/templates/10-readability-deployment.yaml
+++ b/deployment/readability/templates/10-readability-deployment.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: arxiv-readability
+  labels:
+    subsystem: "{{ .Values.labels.subsystem }}"
+    container: readability
+    service-group: ui
+    log-style: uwsgi
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        subsystem: "{{ .Values.labels.subsystem }}"
+        container: readability
+        service-group: ui
+        log-style: uwsgi
+      annotations:
+        prometheus.io/scrape: 'true'
+    spec:
+      containers:
+      - name: arxiv-readability
+        image: arxiv/readability:{{ .Values.imageTag }}
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8000
+        env:
+        - name: DATABASE_URL
+          value: "{{ .Values.database_url }}"
+        - name: CELERY_BROKER_URL
+          value: "redis://{{ .Values.redis.host }}:{{ .Values.redis.port}}"
+        - name: CELERY_RESULT_BACKEND
+          value: "redis://{{ .Values.redis.host }}:{{ .Values.redis.port}}"
+        - name: SECRET_KEY
+          value: "{{ .Values.secret_key }}"
+        - name: DEBUG
+          value: "1"
+        - name: SCRIPT_NAME
+          value: "{{ .Values.script_name }}"
+        - name: FORCE_SCRIPT_NAME
+          value: "{{ .Values.script_name }}"
+        - name: DJANGO_LOG_LEVEL
+          value: "DEBUG"
+        - name: ALLOWED_HOSTS
+          value: "*"
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: arxiv-readability-worker
+  labels:
+    subsystem: "{{ .Values.labels.subsystem }}"
+    container: readability-worker
+    service-group: backend
+    log-style: celery
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        subsystem: "{{ .Values.labels.subsystem }}"
+        container: readability-worker
+        service-group: backend
+        log-style: celery
+      annotations:
+        prometheus.io/scrape: 'true'
+    spec:
+      containers:
+      - name: arxiv-readability-worker
+        image: arxiv/readability:{{ .Values.imageTag }}
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8000
+        command:
+          - "sh"
+          - "-c"
+          - >
+            watchmedo auto-restart --recursive -d . -p '*.py' -- celery -A arxiv_html worker -l info
+        env:
+        - name: DATABASE_URL
+          value: "{{ .Values.database_url }}"
+        - name: CELERY_BROKER_URL
+          value: "redis://{{ .Values.redis.host }}:{{ .Values.redis.port}}"
+        - name: CELERY_RESULT_BACKEND
+          value: "redis://{{ .Values.redis.host }}:{{ .Values.redis.port}}"
+        - name: SECRET_KEY
+          value: "{{ .Values.secret_key }}"
+        - name: ALLOWED_HOSTS
+          value: "*"

--- a/deployment/readability/values.yaml
+++ b/deployment/readability/values.yaml
@@ -1,0 +1,10 @@
+labels:
+  subsystem: labs
+database_url: psql://postgres@db:5432/postgres
+redis:
+  host: readability-redis-master
+  port: 6379
+namespace: development
+imageTag: latest
+secret_key: thisisnotasecret!
+script_name: /

--- a/script/deploy
+++ b/script/deploy
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash
+#!/bin/bash
+set -e
+set -v
 set -o pipefail
 set -o errexit
 set -o nounset

--- a/script/deploy
+++ b/script/deploy
@@ -17,7 +17,7 @@ chmod +x ./kubectl
 sudo mv ./kubectl /usr/local/bin/kubectl
 curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
 chmod 700 get_helm.sh
-sudo ./get_helm.sh
+sudo ./get_helm.sh -v v2.8.0
 
 # Configure Kubernetes & Helm
 echo $CA_CERT | base64 --decode > ${HOME}/ca.crt

--- a/script/deploy
+++ b/script/deploy
@@ -29,7 +29,7 @@ kubectl config current-context
 helm init --client-only --tiller-namespace $CLUSTER_NAMESPACE --namespace $CLUSTER_NAMESPACE
 
 # Deploy to Kubernetes.
-helm upgrade readability ./deployment/readability --set=script_name=/dev/html --tiller-namespace $CLUSTER_NAMESPACE --namespace $CLUSTER_NAMESPACE
+helm upgrade readability ./deployment/readability --set=imageTag=$TRAVIS_COMMIT --set=script_name=/dev/html --tiller-namespace $CLUSTER_NAMESPACE --namespace $CLUSTER_NAMESPACE
 
 function cleanup {
     printf "Cleaning up...\n"

--- a/script/deploy
+++ b/script/deploy
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-set -v
+# set -v
 set -o pipefail
 set -o errexit
 set -o nounset

--- a/script/deploy
+++ b/script/deploy
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -o pipefail
+set -o errexit
+set -o nounset
+# set -o xtrace
+
+# Build and push the docker image.
+docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
+docker build . -t arxiv/readability:${TRAVIS_COMMIT};
+docker push arxiv/readability:${TRAVIS_COMMIT}
+
+# Install kubectl & Helm
+curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.9.2/bin/linux/amd64/kubectl
+chmod +x ./kubectl
+sudo mv ./kubectl /usr/local/bin/kubectl
+curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
+chmod 700 get_helm.sh
+sudo ./get_helm.sh
+
+# Configure Kubernetes & Helm
+echo $CA_CERT | base64 --decode > ${HOME}/ca.crt
+
+kubectl config set-cluster $CLUSTER_NAME --embed-certs=true --server=$CLUSTER_ENDPOINT --certificate-authority=${HOME}/ca.crt
+kubectl config set-credentials $CLUSTER_SA --token=$(echo $SA_TOKEN | base64 --decode)
+kubectl config set-context travis --cluster=$CLUSTER_NAME --user=$CLUSTER_SA --namespace=$CLUSTER_NAMESPACE
+kubectl config use-context travis
+kubectl config current-context
+
+helm init --client-only --tiller-namespace $CLUSTER_NAMESPACE --namespace $CLUSTER_NAMESPACE
+
+# Deploy to Kubernetes.
+helm upgrade readability ./deployment/readability --set=script_name=/dev/html --tiller-namespace $CLUSTER_NAMESPACE --namespace $CLUSTER_NAMESPACE
+
+function cleanup {
+    printf "Cleaning up...\n"
+    rm -vf "${HOME}/ca.crt"
+    printf "Cleaning done."
+}
+
+trap cleanup EXIT

--- a/script/deploy
+++ b/script/deploy
@@ -28,7 +28,7 @@ kubectl config set-context travis --cluster=$CLUSTER_NAME --user=$CLUSTER_SA --n
 kubectl config use-context travis
 kubectl config current-context
 
-helm init --client-only --tiller-namespace $CLUSTER_NAMESPACE --namespace $CLUSTER_NAMESPACE
+helm init --client-only --tiller-namespace $CLUSTER_NAMESPACE 
 
 # Deploy to Kubernetes.
 helm upgrade readability ./deployment/readability --set=imageTag=$TRAVIS_COMMIT --set=script_name=/dev/html --tiller-namespace $CLUSTER_NAMESPACE --namespace $CLUSTER_NAMESPACE

--- a/script/deploy
+++ b/script/deploy
@@ -23,12 +23,12 @@ sudo ./get_helm.sh
 echo $CA_CERT | base64 --decode > ${HOME}/ca.crt
 
 kubectl config set-cluster $CLUSTER_NAME --embed-certs=true --server=$CLUSTER_ENDPOINT --certificate-authority=${HOME}/ca.crt
-kubectl config set-credentials $CLUSTER_SA --token=$(echo $SA_TOKEN | base64 --decode)
+kubectl config set-credentials $CLUSTER_SA --token=$(echo $USER_TOKEN | base64 --decode)
 kubectl config set-context travis --cluster=$CLUSTER_NAME --user=$CLUSTER_SA --namespace=$CLUSTER_NAMESPACE
 kubectl config use-context travis
 kubectl config current-context
 
-helm init --client-only --tiller-namespace $CLUSTER_NAMESPACE 
+helm init --client-only --tiller-namespace $CLUSTER_NAMESPACE
 
 # Deploy to Kubernetes.
 helm upgrade readability ./deployment/readability --set=imageTag=$TRAVIS_COMMIT --set=script_name=/dev/html --tiller-namespace $CLUSTER_NAMESPACE --namespace $CLUSTER_NAMESPACE


### PR DESCRIPTION
This adds a deploy process for commits on the `master` branch. The docker image is tagged with the current commit, pushed to hub.docker.com, and then deployed in a development namespace on the arXiv platform.

One outstanding problem is making Django happy running at a subsidiary path. Using ``FORCE_SCRIPT_NAME`` at least takes care of redirects, but static files are a bit of a mess. That being said, it may not matter much as I assume we'll be serving those off of S3 or similar.

Note that I have not yet provisioned nor configured a database nor S3 buckets for the dev deployment. The app does deploy with its own redis, however, so at least that bit should be working. 